### PR TITLE
fix response typo.

### DIFF
--- a/_posts/2018-01-25-get-graph-pixels.md
+++ b/_posts/2018-01-25-get-graph-pixels.md
@@ -36,4 +36,4 @@ You can specify a period with from and to parameters.<br>
 ### Example
 
 ```$ curl -X GET https://pixe.la/v1/users/a-know/graphs/test-graph/pixels?from=20180101&to=20181231 -H 'X-USER-TOKEN:thisissecret'
-{"pixels":["20180101","20180331","20180402","20180505","20181204"}]}```
+{"pixels":["20180101","20180331","20180402","20180505","20181204"]}```

--- a/_posts/2018-01-30-get-graph.md
+++ b/_posts/2018-01-30-get-graph.md
@@ -19,4 +19,4 @@ Get all predefined pixelation graph definitions.
 ### Example
 
 ```$ curl -X GET https://pixe.la/v1/users/a-know/graphs -H 'X-USER-TOKEN:thisissecret'
-{"graphs":[{"id":"test-graph","name":"graph-name","unit":"commit","type":"int","color":"shibafu","timezone":"Asia/Tokyo","purgeCacheURLs":["https://camo.githubusercontent.com/xxx/xxxx","selfSufficient":"increment"]}]}```
+{"graphs":[{"id":"test-graph","name":"graph-name","unit":"commit","type":"int","color":"shibafu","timezone":"Asia/Tokyo","purgeCacheURLs":["https://camo.githubusercontent.com/xxx/xxxx"],"selfSufficient":"increment"}]}```


### PR DESCRIPTION
I notice that some API response descriptions of [API document](https://docs.pixe.la/) are invalid  (possibly typo).

Followings are adjusting points.

* 2018-01-25-get-graph-pixels.md
    * remove unmatch curly bracket after `pixels` value.
* 2018-01-30-get-graph.md
    * move unmatch square bracket after `selfSufficient` value to `purgeURLs` value.

Could you check and merge?